### PR TITLE
image normalizer func: normalize tensor based on mean, std

### DIFF
--- a/fastnet/data/image_augmentations.py
+++ b/fastnet/data/image_augmentations.py
@@ -3,6 +3,8 @@ import numpy as np
 import tensorflow as tf
 import os
 
+from typing import List, Union, Callable
+
 import logging
 logger = logging.getLogger("Image Augmentations")
 logger.setLevel(logging.INFO)
@@ -97,3 +99,8 @@ def combine_transformers(*transformers):
         return tuple(args)
     return wrapper
 
+def get_image_normalizer(mean: Union[List, np.ndarray], std: Union[np.ndarray]) -> Callable:
+    "Returns a function that normalizes a tensor image with given mean, std. Usage same as other transformers"
+    def normalizer(x: tf.Tensor) -> tf.Tensor:
+        return (x-mean)/std
+    return normalizer


### PR DESCRIPTION
Normalize tensor based on mean, std

Example usage: 

```
mean = [125.30691805, 122.95039414, 113.86538318]
std = [62.99321928, 62.08870764, 66.70489964]

normalizer = fn.get_first_argument_transformer(get_image_normalizer(mean=mean, std=std))
transformations = fn.combine_transformers(normalizer)

train = train.map(transformations).map(lambda x,y: (x/255.0,y)).prefetch(buffer_size=tf.data.experimental.AUTOTUNE)


```